### PR TITLE
Disable validating schema by default (closes #2)

### DIFF
--- a/scl-validating.ts
+++ b/scl-validating.ts
@@ -59,7 +59,7 @@ export default class SclValidatingPlugin extends LitElement {
   @state() waitForTemplateRun = true;
 
   /** Whether schema validator shall run after each change to the doc */
-  @state() autoValidateSchema = true;
+  @state() autoValidateSchema = false;
 
   /** Whether template validator shall run after each change to the doc */
   @state() autoValidateTemplate = false;
@@ -235,7 +235,6 @@ export default class SclValidatingPlugin extends LitElement {
               <mwc-formfield label="Auto validate on change" alignEnd>
                 <mwc-switch
                   class="auto schema"
-                  selected
                   @click="${() => {
                     this.autoValidateSchema = !this.autoValidateSchema;
                   }}"


### PR DESCRIPTION
Disables the validator running by default as there appears to either a memory leak or objects being somehow retained.

Regrettably we have not been able to diagnose this in the last year or so and it compromises the reliability of a distribution in which it is included.

Closes #2